### PR TITLE
Add Smokeburst McCarty as model KC

### DIFF
--- a/MODCAT_data.js
+++ b/MODCAT_data.js
@@ -39,6 +39,7 @@ const prs = {
     modelJA : "JA-15",
     modelJH : "Johnny Hiland",
     modelJT : "SC Jumbo Thinline",
+    modelKC : "Smokeburst McCarty",
     modelM2 : "McCarty 2",
     modelM3 : "Studio",
     modelM5 : "McCarty 594",


### PR DESCRIPTION
This PR adds the model `KC` to the `prs` var list.

The model id can be found in the 2009 price list for PRS. This appears to be a one-off code for the mahogany based model **Smokeburst McCarty** from 2009:

http://jedistar.com/pdf/prs/prs_pricelist_2009.pdf

![image](https://user-images.githubusercontent.com/746152/76427948-c4b4ab00-638b-11ea-9df3-59da2ad63136.png)


## Before
![image](https://user-images.githubusercontent.com/746152/76428496-8075da80-638c-11ea-87b6-84dce2c1318e.png)

## After

![image](https://user-images.githubusercontent.com/746152/76427993-d6964e00-638b-11ea-8d39-692d9f702f58.png)

### Real life proof:

![image](https://user-images.githubusercontent.com/746152/76428317-473d6a80-638c-11ea-8343-a4cde800eed5.png)

Example MODCAT: `KCM2F-HFIIS_KB_NK-K3`





