### PR TITLE
Update for 35th. Force underscores for color.

### DIFF
--- a/MODCAT_data.js
+++ b/MODCAT_data.js
@@ -1,5 +1,6 @@
 const prs = {
     model18 : "KL1812",
+    model35 : "35th Anniversary Custom 24",
     model38 : "KL380",
     model48 : "408 Maple/Std Model",
     model4N : "Neal Schon 14",
@@ -430,7 +431,7 @@ const prs = {
     elec5 : "5-Way Rotary",
     elec7 : "Singlecut",
     elec9 : "509",
-    elecA : "Paul's", //May also be bass?
+    elecA : "Selector and Two Mini Toggle Coil-Tap Switches", // Paul's, 35th Anniversary
     elecB : "5-Way Blade or Grainger Bass 4/5",
     elecF : "513",
     elecH : "Henderson",

--- a/decode.js
+++ b/decode.js
@@ -26,6 +26,17 @@ const addFieldValuesToDOM = () => {
 
 const getCodesFromString = str => {
     str = format(str);
+
+    if (str.length < 20) {
+        numUnderscores = 20 - str.length;
+        underscores = "";
+        for ( i=0; i < numUnderscores; i++ ) {
+            underscores += "_";
+        }
+        str = [str.slice(0, 11), underscores, str.slice(11)].join('');
+        console.log("MODCAT reconstructed to " + str);
+    }
+
     modelCode = str.substring(0, 2);
     topWoodCode = str.substring(2, 3);
     fretsCode = str.substring(3, 4);
@@ -36,7 +47,9 @@ const getCodesFromString = str => {
     fingerboardCode = str.substring(8, 9);
     inlayCode = str.substring(9, 10);
     bridgeCode = str.substring(10, 11);
-    colorCode = str.substring(11, 15).replace(/_/g, "");
+    if ( colorCode != '____') {
+        colorCode = str.substring(11, 15).replace(/_/g, "");
+    }
     hardwareCode = str.substring(15, 16);
     treblepuCode = str.substring(16, 17);
     middlepuCode = str.substring(17, 18);


### PR DESCRIPTION
- Added new model entry for 35th Anniversary Custom 24.
- Updated description for "elecA" since this layout is no longer specific to the Paul's Guitar.
- Added logic to add filler underscores to the color code (at index 11) if total string length is < 20, since that is the code that is usually omitted. I have done a limited amount of testing with various MODCATs that have previously given me trouble, and the results are promising, but this could benefit from additional testing.